### PR TITLE
Add code formatting to /group/ctbrowngrp/

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -176,7 +176,7 @@ you probably need to use a different partition; see
 [Partitions/queues we have available](partitions.md).
 
 ## Shared storage
-For files shared among users (references, databases, etc), use /group/ctbrowngrp/ to avoid having redundant files.
+For files shared among users (references, databases, etc), use `/group/ctbrowngrp/` to avoid having redundant files.
 
 ## Using shared resources
 


### PR DESCRIPTION
This PR changes "/group/ctbrowngrp/" --> "`/group/ctbrowngrp/`" to make it more obvious to find the path when scanning the document